### PR TITLE
Add missing script name to setup instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Please see `scripts/ugreen-leds.conf` for an example.
 - Copy files in the `scripts` directory: 
   ```bash
   # copy the scripts
-  scripts=(ugreen-diskiomon ugreen-netdevmon ugreen-probe-leds)
+  scripts=(ugreen-diskiomon ugreen-netdevmon ugreen-probe-leds ugreen-power-led)
   for f in ${scripts[@]}; do
       chmod +x "scripts/$f"
       cp "scripts/$f" /usr/bin


### PR DESCRIPTION
Added the missing `ugreen-power-led` script reference to the setup instructions in the README.md

If the script is missing due to not being copied during setup, the following error will occur:

```plaintext
 ugreen-power-led.service: Failed at step EXEC spawning /usr/bin/ugreen-power-led: No such file or directory
 Subject: Process /usr/bin/ugreen-power-led could not be executed
 Defined-By: systemd
 Support: https://www.debian.org/support
 
 The process /usr/bin/ugreen-power-led could not be executed and failed.
 
 The error number returned by this process is 2.
```